### PR TITLE
fix: correct backend health check implementation

### DIFF
--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -43,10 +43,13 @@ export async function sendLumens(recipient, amount) {
  */
 export async function checkBackendHealth() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/send`, {
-      method: "OPTIONS",
-    });
-    return response.ok || response.status === 405; // 405 means endpoint exists but OPTIONS not allowed
+    const response = await fetch(`${API_BASE_URL}/api/health`);
+    if (!response.ok) {
+      return false;
+    }
+
+  const data = await response.json();
+  return data && typeof data.status === "string" && data.status.toLowerCase() === "ok";
   } catch (error) {
     console.error("Backend health check failed:", error);
     return false;


### PR DESCRIPTION
Closes #23 
### **Summary**

1. Update frontend health check to use the dedicated /api/health endpoint instead of probing /api/send with an OPTIONS request.
2. Simplify [checkBackendHealth] to match the Go backend’s JSON response ([{ "status": "ok", ... }]and return a simple boolean.

Let me know if you require me to change anything