### PR TITLE
feat: wire up TransactionHistory component with real Horizon data

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import HomePage from './components/HomePage';
 import EmployerDashboard from './components/EmployerDashboard';
+import TransactionHistory from './components/TransactionHistory';
+import { useWallet } from './hooks/useWallet';
 
 function App() {
   const [view, setView] = useState('home');
+  const { transactions } = useWallet();
 
   return (
     <>
@@ -24,6 +27,7 @@ function App() {
         </button>
       </div>
       {view === 'employer' ? <EmployerDashboard /> : <HomePage />}
+      <TransactionHistory transactions={transactions} />
     </>
   );
 }

--- a/client/src/hooks/useWallet.js
+++ b/client/src/hooks/useWallet.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import * as freighterApi from "@stellar/freighter-api";
-import { getWalletTokenBalances, fetchExchangeRates } from "../services/sorobanService";
+import { getWalletTokenBalances, fetchExchangeRates, getTransactionHistory } from "../services/sorobanService";
 
 /**
  * Custom hook for managing Freighter wallet connection + multi-token balances
@@ -17,7 +17,7 @@ export function useWallet() {
   const [selectedToken, setSelectedToken] = useState(null);
   const [exchangeRates, setExchangeRates] = useState({});
   const [loadingBalances, setLoadingBalances] = useState(false);
-
+  const [transactions, setTransactions] = useState([]);
   // Check if Freighter is installed and if already connected
   useEffect(() => {
     let mounted = true;
@@ -66,13 +66,16 @@ export function useWallet() {
     const loadBalancesAndRates = async () => {
       setLoadingBalances(true);
       try {
-        const [balances, rates] = await Promise.all([
+        const [balances, rates , txHistory] = await Promise.all([
           getWalletTokenBalances(walletAddress),
           fetchExchangeRates(),
+          getTransactionHistory(walletAddress),
         ]);
 
         setTokenBalances(balances);
         setExchangeRates(rates);
+        setTransactions(txHistory);
+
 
         // Auto-select first token with balance, or XLM by default
         if (balances.length > 0 && !selectedToken) {
@@ -104,6 +107,16 @@ export function useWallet() {
       console.error("Failed to refresh balances:", err);
     } finally {
       setLoadingBalances(false);
+    }
+  }, [walletAddress]);
+    
+  const refreshTransactions = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const txHistory = await getTransactionHistory(walletAddress);
+      setTransactions(txHistory);
+    } catch (err) {
+      console.error("Failed to refresh transactions:", err);
     }
   }, [walletAddress]);
 
@@ -195,6 +208,8 @@ export function useWallet() {
     loadingBalances,
     refreshBalances,
     getUsdValue,
+    transactions,
+    refreshTransactions,
   };
 }
 

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -344,6 +344,29 @@ export const CONTRACTS = {
   WAGE: CONTRACT_ADDRESS_WAGE,
   RPC_URL,
 };
+export async function getTransactionHistory(publicKey) {
+  try {
+    const response = await fetch(
+      `https://horizon-testnet.stellar.org/accounts/${publicKey}/operations?limit=20&order=desc`
+    );
+    if (!response.ok) throw new Error("Failed to fetch transaction history");
+
+    const data = await response.json();
+
+    return data._embedded.records.map((op) => ({
+      hash: op.transaction_hash,
+      type: op.type === "payment" ? (op.to === publicKey ? "Receive" : "Send") : op.type,
+      amount: parseFloat(op.amount || 0),
+      date: op.created_at,
+      status: "completed",
+      recipient: op.to || null,
+      fee: 0,
+    }));
+  } catch (error) {
+    console.error("Error fetching transaction history:", error);
+    return [];
+  }
+}
 
 export default {
   registerEmployee,
@@ -355,6 +378,7 @@ export default {
   releaseRemainingSalary,
   getWalletTokenBalances,
   fetchExchangeRates,
+  getTransactionHistory,
   SUPPORTED_TOKENS,
   CONTRACTS,
 };


### PR DESCRIPTION
**Problem**
TransactionHistory component existed with a complete UI but was never connected to real data or even rendered in App.jsx. No transaction state in useWallet, no fetch function in sorobanService.

**Changes**
- `sorobanService.js`: added `getTransactionHistory(publicKey)` that hits the Horizon testnet operations endpoint and maps results to the shape the component expects
- `useWallet.js`: added `transactions` state that loads on wallet connect alongside balances, exposed `refreshTransactions` callback
- `App.jsx`: rendered `TransactionHistory` and passed transactions down from `useWallet`

**Result**
Users can now see their operation history after connecting their wallet, with links to stellar.expert for each transaction hash.

Closes #34