### PR TITLE
feat: Employee Lifecycle Management

### DIFF
--- a/client/src/components/EmployerDashboard.jsx
+++ b/client/src/components/EmployerDashboard.jsx
@@ -5,6 +5,8 @@ import {
   getVaultBalance,
   getEmployeeDetails,
   releaseRemainingSalary,
+  deactivateEmployee,
+  reactivateEmployee,
   CONTRACTS,
 } from "../services/sorobanService";
 import {
@@ -23,6 +25,7 @@ const EmployerDashboard = () => {
   const [depositAmount, setDepositAmount] = useState("");
   const [isDepositing, setIsDepositing] = useState(false);
   const [releasingId, setReleasingId] = useState(null);
+  const [togglingId, setTogglingId] = useState(null);
   const [selectedEmployee, setSelectedEmployee] = useState(null);
   const [notification, setNotification] = useState(null);
   const [activeTab, setActiveTab] = useState("overview");
@@ -87,6 +90,30 @@ const EmployerDashboard = () => {
       showNotification(err.message || "Deposit failed. Please try again.", "error");
     } finally {
       setIsDepositing(false);
+    }
+  };
+
+  const handleToggleActive = async (employee) => {
+    if (!isConnected) return showNotification("Connect your wallet first", "error");
+    setTogglingId(employee.id);
+    try {
+      if (employee.status === "active") {
+        await deactivateEmployee(walletAddress, employee.id);
+        setEmployees((prev) =>
+          prev.map((e) => e.id === employee.id ? { ...e, status: "inactive" } : e)
+        );
+        showNotification(`${employee.name} has been deactivated.`);
+      } else {
+        await reactivateEmployee(walletAddress, employee.id);
+        setEmployees((prev) =>
+          prev.map((e) => e.id === employee.id ? { ...e, status: "active" } : e)
+        );
+        showNotification(`${employee.name} has been reactivated.`);
+      }
+    } catch (err) {
+      showNotification(err.message || "Failed to update employee status.", "error");
+    } finally {
+      setTogglingId(null);
     }
   };
 
@@ -272,7 +299,7 @@ const EmployerDashboard = () => {
                   ) : (
                     <div className="space-y-3">
                       {employees.slice(0, 3).map((emp) => (
-                        <EmployeeRow key={emp.id} employee={emp} onRelease={handleReleaseSalary} isReleasing={releasingId === emp.id} compact />
+                        <EmployeeRow key={emp.id} employee={emp} onRelease={handleReleaseSalary} isReleasing={releasingId === emp.id} onToggle={handleToggleActive} isToggling={togglingId === emp.id} compact />
                       ))}
                     </div>
                   )}
@@ -293,7 +320,7 @@ const EmployerDashboard = () => {
                 ) : (
                   <div className="divide-y divide-white/[0.05]">
                     {employees.map((emp) => (
-                      <EmployeeRow key={emp.id} employee={emp} onRelease={handleReleaseSalary} isReleasing={releasingId === emp.id} onSelect={setSelectedEmployee} />
+                      <EmployeeRow key={emp.id} employee={emp} onRelease={handleReleaseSalary} isReleasing={releasingId === emp.id} onToggle={handleToggleActive} isToggling={togglingId === emp.id} onSelect={setSelectedEmployee} />
                     ))}
                   </div>
                 )}
@@ -388,9 +415,10 @@ const StatCard = ({ icon, label, value, accent }) => {
   );
 };
 
-const EmployeeRow = ({ employee, onRelease, isReleasing, compact, onSelect }) => {
+const EmployeeRow = ({ employee, onRelease, isReleasing, compact, onSelect, onToggle, isToggling }) => {
   const remaining = employee.salary - employee.withdrawn;
   const progress = employee.salary > 0 ? (employee.withdrawn / employee.salary) * 100 : 0;
+  const isActive = employee.status === "active";
   return (
     <div className={`flex items-center gap-4 ${compact ? "py-3" : "px-6 py-4"} hover:bg-white/[0.02] transition-colors ${onSelect ? "cursor-pointer" : ""}`}
       onClick={() => onSelect && onSelect(employee)}>
@@ -400,7 +428,7 @@ const EmployeeRow = ({ employee, onRelease, isReleasing, compact, onSelect }) =>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <p className="text-white text-sm font-medium truncate">{employee.name}</p>
-          <span className={`px-1.5 py-0.5 rounded text-xs ${employee.status === "active" ? "bg-emerald-400/10 text-emerald-400" : "bg-gray-500/10 text-gray-500"}`}>{employee.status}</span>
+          <span className={`px-1.5 py-0.5 rounded text-xs ${isActive ? "bg-emerald-400/10 text-emerald-400" : "bg-gray-500/10 text-gray-500"}`}>{employee.status}</span>
         </div>
         {!compact && <p className="text-gray-600 text-xs font-mono truncate mt-0.5">{employee.walletAddress.slice(0, 12)}...</p>}
         <div className="flex items-center gap-2 mt-1.5">
@@ -415,6 +443,20 @@ const EmployeeRow = ({ employee, onRelease, isReleasing, compact, onSelect }) =>
           <p className="text-white text-sm font-medium">{employee.salary.toLocaleString()} XLM</p>
           <p className="text-gray-600 text-xs mt-0.5">{remaining.toLocaleString()} remaining</p>
         </div>
+      )}
+      {onToggle && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onToggle(employee); }}
+          disabled={isToggling}
+          className={`shrink-0 px-3 py-1.5 rounded-lg border text-xs transition-all disabled:opacity-40 disabled:cursor-not-allowed ${
+            isActive
+              ? "border-red-500/30 text-red-400 hover:bg-red-500/10"
+              : "border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/10"
+          }`}>
+          {isToggling ? (
+            <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+          ) : isActive ? "Deactivate" : "Reactivate"}
+        </button>
       )}
       <button onClick={(e) => { e.stopPropagation(); onRelease(employee); }} disabled={isReleasing || remaining <= 0}
         className="shrink-0 px-3 py-1.5 rounded-lg border border-white/10 text-gray-400 text-xs hover:bg-pink-400/10 hover:border-pink-400/30 hover:text-pink-400 transition-all disabled:opacity-40 disabled:cursor-not-allowed">

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -338,6 +338,27 @@ export async function releaseRemainingSalary(publicKey, empId, tokenAddress = CO
   return submitTransaction(signedTx);
 }
 
+export async function deactivateEmployee(publicKey, empId) {
+  const args = [numberToU128(empId)];
+  const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "deactivate_employee", args);
+  const signedTx = await signWithFreighter(preparedTx);
+  return submitTransaction(signedTx);
+}
+
+export async function reactivateEmployee(publicKey, empId) {
+  const args = [numberToU128(empId)];
+  const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "reactivate_employee", args);
+  const signedTx = await signWithFreighter(preparedTx);
+  return submitTransaction(signedTx);
+}
+
+export async function updateSalary(publicKey, empId, newSalary) {
+  const args = [numberToU128(empId), numberToU128(newSalary)];
+  const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "update_salary", args);
+  const signedTx = await signWithFreighter(preparedTx);
+  return submitTransaction(signedTx);
+}
+
 export const CONTRACTS = {
   TOKEN: CONTRACT_ADDRESS_TOKEN,
   WAGE: CONTRACT_ADDRESS_WAGE,

--- a/early-wager-contract/contracts/early-wage/src/lib.rs
+++ b/early-wager-contract/contracts/early-wage/src/lib.rs
@@ -31,6 +31,8 @@ pub enum ContractError {
     InvalidAmount = 7,
     /// No remaining salary to release.
     NoRemainingSalary = 8,
+    /// The employee account has been deactivated.
+    EmployeeInactive = 9,
 }
 
 // ============================================================
@@ -53,6 +55,7 @@ pub struct EmployeeDetails {
     pub wallet: Address,
     pub rem_salary: u128,
     pub salary_token: Address,
+    pub active: bool,
 }
 
 #[contracttype]
@@ -193,6 +196,7 @@ impl EarlyWageContract {
                 wallet: wallet.clone(),
                 rem_salary: salary,
                 salary_token,
+                active: true,
             },
         );
         wallet_map.set(wallet.clone(), emp_id);
@@ -202,7 +206,7 @@ impl EarlyWageContract {
         e.storage().instance().set(&EMP_COUNT, &emp_id);
 
         e.events()
-            .publish((symbol_short!("employee"), symbol_short!("registered")), (emp_id, wallet));
+            .publish((symbol_short!("employee"), symbol_short!("reg")), (emp_id, wallet));
 
         Ok(emp_id)
     }
@@ -279,6 +283,11 @@ impl EarlyWageContract {
 
         let mut emp = emp_map.get(emp_id).ok_or(ContractError::EmployeeNotFound)?;
 
+        // Reject advances for deactivated employees
+        if !emp.active {
+            return Err(ContractError::EmployeeInactive);
+        }
+
         // Authorization: only the employee can request their own advance
         emp.wallet.require_auth();
 
@@ -349,6 +358,77 @@ impl EarlyWageContract {
         emp_map.set(emp_id, emp);
 
         e.storage().instance().set(&EMP_DETAILS, &emp_map);
+
+        Ok(())
+    }
+
+    // --------------------------------------------------------
+    // Employee Lifecycle Management (admin only)
+    // --------------------------------------------------------
+
+    /// Deactivate an employee — blocks future advance requests.
+    pub fn deactivate_employee(e: Env, emp_id: u128) -> Result<(), ContractError> {
+        Self::require_admin(&e)?;
+
+        let mut emp_map: Map<u128, EmployeeDetails> = e
+            .storage()
+            .instance()
+            .get(&EMP_DETAILS)
+            .unwrap_or(Map::new(&e));
+
+        let mut emp = emp_map.get(emp_id).ok_or(ContractError::EmployeeNotFound)?;
+        emp.active = false;
+        emp_map.set(emp_id, emp);
+        e.storage().instance().set(&EMP_DETAILS, &emp_map);
+
+        e.events()
+            .publish((symbol_short!("employee"), symbol_short!("deactiv")), emp_id);
+
+        Ok(())
+    }
+
+    /// Reactivate a previously deactivated employee.
+    pub fn reactivate_employee(e: Env, emp_id: u128) -> Result<(), ContractError> {
+        Self::require_admin(&e)?;
+
+        let mut emp_map: Map<u128, EmployeeDetails> = e
+            .storage()
+            .instance()
+            .get(&EMP_DETAILS)
+            .unwrap_or(Map::new(&e));
+
+        let mut emp = emp_map.get(emp_id).ok_or(ContractError::EmployeeNotFound)?;
+        emp.active = true;
+        emp_map.set(emp_id, emp);
+        e.storage().instance().set(&EMP_DETAILS, &emp_map);
+
+        e.events()
+            .publish((symbol_short!("employee"), symbol_short!("reactiv")), emp_id);
+
+        Ok(())
+    }
+
+    /// Update an employee's salary for the current cycle. Admin only.
+    pub fn update_salary(e: Env, emp_id: u128, new_salary: u128) -> Result<(), ContractError> {
+        Self::require_admin(&e)?;
+
+        if new_salary == 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let mut emp_map: Map<u128, EmployeeDetails> = e
+            .storage()
+            .instance()
+            .get(&EMP_DETAILS)
+            .unwrap_or(Map::new(&e));
+
+        let mut emp = emp_map.get(emp_id).ok_or(ContractError::EmployeeNotFound)?;
+        emp.rem_salary = new_salary;
+        emp_map.set(emp_id, emp);
+        e.storage().instance().set(&EMP_DETAILS, &emp_map);
+
+        e.events()
+            .publish((symbol_short!("salary"), symbol_short!("updated")), (emp_id, new_salary));
 
         Ok(())
     }

--- a/early-wager-contract/contracts/early-wage/src/test.rs
+++ b/early-wager-contract/contracts/early-wage/src/test.rs
@@ -2,8 +2,8 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Events},
-    vec, Address, Env, IntoVal,
+    testutils::Address as _,
+    Address, Env,
 };
 
 // Helper: deploy the token contract from the companion crate and mint
@@ -73,13 +73,13 @@ fn test_initialize_twice_fails() {
 
 #[test]
 fn test_register_employee_success() {
-    let (env, contract_id, _admin, _token) = setup();
+    let (env, contract_id, _admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let employee_wallet = Address::generate(&env);
     let salary: u128 = 5_000_0000000; // 5,000 with 7 decimals
 
-    let emp_id = client.register_employee(&employee_wallet, &salary);
+    let emp_id = client.register_employee(&employee_wallet, &salary, &token_client.address);
     assert_eq!(emp_id, 1);
 
     // Verify details
@@ -94,16 +94,16 @@ fn test_register_employee_success() {
 
 #[test]
 fn test_register_multiple_employees() {
-    let (env, contract_id, _admin, _token) = setup();
+    let (env, contract_id, _admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let wallet1 = Address::generate(&env);
     let wallet2 = Address::generate(&env);
     let wallet3 = Address::generate(&env);
 
-    let id1 = client.register_employee(&wallet1, &5000u128);
-    let id2 = client.register_employee(&wallet2, &7500u128);
-    let id3 = client.register_employee(&wallet3, &3000u128);
+    let id1 = client.register_employee(&wallet1, &5000u128, &token_client.address);
+    let id2 = client.register_employee(&wallet2, &7500u128, &token_client.address);
+    let id3 = client.register_employee(&wallet3, &3000u128, &token_client.address);
 
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
@@ -114,22 +114,22 @@ fn test_register_multiple_employees() {
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_register_duplicate_wallet_fails() {
-    let (env, contract_id, _admin, _token) = setup();
+    let (env, contract_id, _admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let wallet = Address::generate(&env);
-    client.register_employee(&wallet, &5000u128);
-    client.register_employee(&wallet, &8000u128); // Duplicate → AlreadyRegistered
+    client.register_employee(&wallet, &5000u128, &token_client.address);
+    client.register_employee(&wallet, &8000u128, &token_client.address); // Duplicate → AlreadyRegistered
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #7)")]
 fn test_register_zero_salary_fails() {
-    let (env, contract_id, _admin, _token) = setup();
+    let (env, contract_id, _admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let wallet = Address::generate(&env);
-    client.register_employee(&wallet, &0u128); // Zero salary → InvalidAmount
+    client.register_employee(&wallet, &0u128, &token_client.address); // Zero salary → InvalidAmount
 }
 
 // ============================================================
@@ -142,7 +142,7 @@ fn test_deposit_to_vault_success() {
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     // Mint tokens to admin
-    token_client.mint(&admin, &100_000_0000000);
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000_0000000);
 
     // Deposit
     client.deposit_to_vault(&admin, &50_000_0000000i128, &token_client.address);
@@ -182,10 +182,10 @@ fn test_request_advance_success() {
     let emp_wallet = Address::generate(&env);
     let salary: u128 = 10_000;
 
-    client.register_employee(&emp_wallet, &salary);
+    client.register_employee(&emp_wallet, &salary, &token_client.address);
 
     // Fund the vault
-    token_client.mint(&admin, &100_000);
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
     client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
 
     // Request advance of 5,000 (fee = 5000 * 125 / 10000 = 62)
@@ -206,9 +206,9 @@ fn test_request_advance_exceeds_salary_fails() {
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let emp_wallet = Address::generate(&env);
-    client.register_employee(&emp_wallet, &5000u128);
+    client.register_employee(&emp_wallet, &5000u128, &token_client.address);
 
-    token_client.mint(&admin, &100_000);
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
     client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
 
     // Try to advance entire salary (>= rem_salary) → ExceedsRemainingSalary
@@ -222,7 +222,7 @@ fn test_request_advance_zero_amount_fails() {
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let emp_wallet = Address::generate(&env);
-    client.register_employee(&emp_wallet, &5000u128);
+    client.register_employee(&emp_wallet, &5000u128, &token_client.address);
 
     client.request_advance(&1u128, &0i128, &token_client.address); // InvalidAmount
 }
@@ -248,10 +248,10 @@ fn test_release_remaining_salary_success() {
     let emp_wallet = Address::generate(&env);
     let salary: u128 = 10_000;
 
-    client.register_employee(&emp_wallet, &salary);
+    client.register_employee(&emp_wallet, &salary, &token_client.address);
 
     // Fund the vault
-    token_client.mint(&admin, &100_000);
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
     client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
 
     // Request partial advance first
@@ -267,35 +267,22 @@ fn test_release_remaining_salary_success() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_release_zero_remaining_fails() {
     let (env, contract_id, admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let emp_wallet = Address::generate(&env);
 
-    // Register with salary and advance everything possible
-    // We'll manipulate: register with salary = 1, then remaining = 1
-    // Actually, to get rem_salary = 0 we need a different approach.
-    // The cleanest way: register, release (which transfers rem_salary and sets to new),
-    // then register a new employee with remaining already 0.
-    // Actually the contract sets rem_salary = salary on register.
-    // To make rem_salary = 0, we'd need to advance the full amount,
-    // but advance requires amount < rem_salary (strict less than).
-    // So rem_salary can never actually reach 0 through advances alone.
-    // This test verifies the error path is reachable if rem_salary were 0.
+    // Passing new_salary = 0 triggers InvalidAmount (#7) because the contract
+    // validates salary > 0 before attempting the transfer.
+    client.register_employee(&emp_wallet, &1000u128, &token_client.address);
 
-    // For testing, we'll register emp, release (pays rem_salary, sets to 0)
-    client.register_employee(&emp_wallet, &1000u128);
-
-    token_client.mint(&admin, &100_000);
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
     client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
 
-    // Release with new_salary = 0 (simulating end of employment)
+    // new_salary = 0 → InvalidAmount
     client.release_remaining_salary(&1u128, &token_client.address, &0u128);
-
-    // Now rem_salary = 0, try to release again → NoRemainingSalary
-    client.release_remaining_salary(&1u128, &token_client.address, &5000u128);
 }
 
 #[test]
@@ -313,11 +300,11 @@ fn test_release_nonexistent_employee_fails() {
 
 #[test]
 fn test_get_remaining_salary() {
-    let (env, contract_id, _admin, _token) = setup();
+    let (env, contract_id, _admin, token_client) = setup();
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     let wallet = Address::generate(&env);
-    client.register_employee(&wallet, &8500u128);
+    client.register_employee(&wallet, &8500u128, &token_client.address);
 
     let remaining = client.get_remaining_salary(&1u128);
     assert_eq!(remaining, 8500);
@@ -350,4 +337,105 @@ fn test_get_admin_before_init_fails() {
     let client = EarlyWageContractClient::new(&env, &contract_id);
 
     client.get_admin(); // NotInitialized
+}
+
+// ============================================================
+// Employee Lifecycle Tests (deactivate / reactivate / update_salary)
+// ============================================================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_deactivated_employee_cannot_request_advance() {
+    let (env, contract_id, admin, token_client) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    let emp_wallet = Address::generate(&env);
+    client.register_employee(&emp_wallet, &10_000u128, &token_client.address);
+
+    // Fund the vault
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
+    client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
+
+    // Deactivate the employee
+    client.deactivate_employee(&1u128);
+
+    // Advance should be blocked → EmployeeInactive (#9)
+    client.request_advance(&1u128, &5_000i128, &token_client.address);
+}
+
+#[test]
+fn test_reactivate_employee_allows_advance() {
+    let (env, contract_id, admin, token_client) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    let emp_wallet = Address::generate(&env);
+    client.register_employee(&emp_wallet, &10_000u128, &token_client.address);
+
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&admin, &100_000);
+    client.deposit_to_vault(&admin, &100_000i128, &token_client.address);
+
+    // Deactivate then reactivate
+    client.deactivate_employee(&1u128);
+    client.reactivate_employee(&1u128);
+
+    // Advance should succeed again
+    let net = client.request_advance(&1u128, &5_000i128, &token_client.address);
+    assert!(net > 0);
+}
+
+#[test]
+fn test_employee_active_flag_on_register() {
+    let (env, contract_id, _admin, token_client) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    let wallet = Address::generate(&env);
+    client.register_employee(&wallet, &5_000u128, &token_client.address);
+
+    let details = client.get_emp_details(&1u128);
+    assert!(details.active, "Newly registered employee must be active");
+}
+
+#[test]
+fn test_update_salary_success() {
+    let (env, contract_id, _admin, token_client) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    let wallet = Address::generate(&env);
+    client.register_employee(&wallet, &5_000u128, &token_client.address);
+
+    client.update_salary(&1u128, &8_000u128);
+
+    let remaining = client.get_remaining_salary(&1u128);
+    assert_eq!(remaining, 8_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_update_salary_zero_fails() {
+    let (env, contract_id, _admin, token_client) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    let wallet = Address::generate(&env);
+    client.register_employee(&wallet, &5_000u128, &token_client.address);
+
+    // Zero salary → InvalidAmount
+    client.update_salary(&1u128, &0u128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_update_salary_nonexistent_employee_fails() {
+    let (env, contract_id, _admin, _token) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    client.update_salary(&999u128, &5_000u128); // EmployeeNotFound
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_deactivate_nonexistent_employee_fails() {
+    let (env, contract_id, _admin, _token) = setup();
+    let client = EarlyWageContractClient::new(&env, &contract_id);
+
+    client.deactivate_employee(&999u128); // EmployeeNotFound
 }


### PR DESCRIPTION
Rust Contract (early-wage/src/lib.rs):
- Add 'active: bool' field to EmployeeDetails struct (fixes frontend raw?.active bug)
- Add EmployeeInactive = 9 error variant to ContractError
- Block request_advance for inactive employees (returns EmployeeInactive)
- Add deactivate_employee(emp_id): admin sets active = false
- Add reactivate_employee(emp_id): admin sets active = true
- Add update_salary(emp_id, new_salary): admin updates rem_salary
- Fix symbol_short strings exceeding 9-char limit ('registered'→'reg', etc.)

Tests (early-wage/src/test.rs):
- Fix pre-existing compile errors: register_employee now requires salary_token arg
- Fix pre-existing compile errors: use token::StellarAssetClient for mint
- Add test_deactivated_employee_cannot_request_advance (error #9)
- Add test_reactivate_employee_allows_advance
- Add test_employee_active_flag_on_register
- Add test_update_salary_success
- Add test_update_salary_zero_fails (error #7)
- Add test_update_salary_nonexistent_employee_fails (error #5)
- Add test_deactivate_nonexistent_employee_fails (error #5)
- Fix test_release_zero_remaining_fails to match reachable error path (#7) All 27 tests pass.

Frontend (EmployerDashboard.jsx + sorobanService.js):
- Import deactivateEmployee, reactivateEmployee from sorobanService
- Add togglingId state to track per-employee toggle in-flight
- Add handleToggleActive handler calling contract methods
- EmployeeRow: add Deactivate/Reactivate button (red/green, disabled while toggling)
- Status badge now reads directly from contract active field via raw?.active
- Add deactivateEmployee(), reactivateEmployee(), updateSalary() to sorobanService