### PR TITLE
fix: wire up new contract query functions to frontend registration flow

### DIFF
--- a/client/src/components/RegistrationCard.jsx
+++ b/client/src/components/RegistrationCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useEmployeeStore } from "../store/empStore";
-import {  registerEmployee } from "../services/sorobanService";//getEmployeeWithWA
+import { registerEmployee, getEmployeeByWallet } from "../services/sorobanService";
 import { useWalletContext } from "../context/WalletContext";
 import Card from "./Cards";
 import Button from "./Button";
@@ -37,7 +37,7 @@ const RegistrationCard = ({ onSuccess }) => {
         }
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
-    }
+    };
 
     const handleSubmit = async (e) => {
         // user registration is handled here
@@ -55,18 +55,20 @@ const RegistrationCard = ({ onSuccess }) => {
 
             // Fast & Safe Recursive Strategy: The blockchain takes a few seconds to sync.
             // We recursively poll the network without blocking the main event thread.
+            // Uses the new two-step query pattern: wallet → emp_id → employee details
+            // Replaces the removed getEmployeeWithWA function (issue #18)
             const safeSyncProfile = async (attempts = 3) => {
-                const data = await getEmployeeWithWA(walletAddress);
-                if (data) return data; // Success! Sync caught up.
+                const result = await getEmployeeByWallet(walletAddress, walletAddress);
+                if (result) return result; // Success! Sync caught up.
                 if (attempts <= 0) throw new Error("Registration confirmed, but profile failed to sync.");
                 await new Promise(res => setTimeout(res, 2000)); // 2-second safe buffer
                 return safeSyncProfile(attempts - 1);
             };
 
-            const empData = await safeSyncProfile();
+            const { empId, details: empData } = await safeSyncProfile();
 
             setEmpData({
-                empId: empData?.empId || null,
+                empId: empId || null,
                 salary: Number(form.salary),
                 email: form.email,
                 isRegistered: true,
@@ -77,15 +79,18 @@ const RegistrationCard = ({ onSuccess }) => {
             // Check if the Blockchain rejected it because we are ALREADY registered
             if (error.message?.includes("InvalidAction") || error.message?.includes("UnreachableCodeReached")) {
                 try {
-                    const existingData = await getEmployeeWithWA(walletAddress);
-                    setEmpData({
-                        empId: existingData?.empId || null,
-                        salary: existingData.rem_salary / 10000000,
-                        email: existingData.email,
-                        isRegistered: true, // Force Zustand to see us!
-                    });
-                    if (onSuccess) onSuccess(); // Notify HomePage
-                    return; // Crucial early exit
+                    const result = await getEmployeeByWallet(walletAddress, walletAddress);
+                    if (result) {
+                        const { empId, details: existingData } = result;
+                        setEmpData({
+                            empId: empId || null,
+                            salary: existingData.rem_salary / 10000000,
+                            email: existingData.email,
+                            isRegistered: true, // Force Zustand to see us!
+                        });
+                        if (onSuccess) onSuccess(); // Notify HomePage
+                        return; // Crucial early exit
+                    }
                 } catch (readErr) {
                     console.error("Failed to fetch existing profile:", readErr);
                 }
@@ -93,11 +98,10 @@ const RegistrationCard = ({ onSuccess }) => {
 
             console.error("CRITICAL REGISTRATION ERROR CAUGHT IN UI:", error);
             setError(error.message || "An error occurred during registration. Please try again.");
-        }
-        finally {
+        } finally {
             setIsLoading(false);
         }
-    }
+    };
 
 
     // Modal is controlled by HomePage state now
@@ -159,9 +163,8 @@ const RegistrationCard = ({ onSuccess }) => {
                     </div>
                 </Card>
             </div>
-
         </>
-    )
-}
+    );
+};
 
 export default RegistrationCard;

--- a/client/src/hooks/checkUser.js
+++ b/client/src/hooks/checkUser.js
@@ -1,4 +1,4 @@
-import { registerEmployee } from "../services/sorobanService.js"; //getEmployeeWithWA,
+import { getEmployeeByWallet } from "../services/sorobanService.js";
 import { useCallback } from "react";
 import { useEmployeeStore } from "../store/empStore.js";
 
@@ -6,7 +6,7 @@ import { useEmployeeStore } from "../store/empStore.js";
 //is registered or not in a system
 
 export function useCheckUser() {
-    //using zustand here 
+    //using zustand here
     //to manage state
     const setEmpData = useEmployeeStore((state) => state.setEmpData);
     const setError = useEmployeeStore((state) => state.setError);
@@ -18,14 +18,20 @@ export function useCheckUser() {
         }
 
         try {
-            setLoading(true)
-            const empData = await getEmployeeWithWA(address);
+            setLoading(true);
+            // Use the new two-step query: wallet → emp_id → employee details
+            // Replaces the removed getEmployeeWithWA function (issue #18)
+            const result = await getEmployeeByWallet(address, address);
+            if (!result) {
+                return { isRegistered: false };
+            }
+            const { empId, details } = result;
             setEmpData({
-                empId: empData.empId,
-                salary: empData.rem_salary / 10000000,
-                email: empData.email,
-            })
-            return { isRegistered: true, empData };
+                empId,
+                salary: details.rem_salary / 10000000,
+                email: details.email,
+            });
+            return { isRegistered: true, empData: details };
 
         } catch (error) {
             console.error("checkUser error details:", error);
@@ -40,11 +46,10 @@ export function useCheckUser() {
             }
 
             return { isRegistered: false };
-        }
-        finally {
+        } finally {
             setLoading(false);
         }
     }, []);
 
-    return { checkUser }
+    return { checkUser };
 }

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -9,64 +9,35 @@ import {
   TransactionBuilder,
   xdr,
 } from "@stellar/stellar-sdk";
-
 import { signTransaction } from "@stellar/freighter-api";
 
 // Contract addresses (set these via VITE_* env vars)
 const CONTRACT_ADDRESS_TOKEN = import.meta.env.VITE_CONTRACT_TOKEN;
-
 const CONTRACT_ADDRESS_WAGE = import.meta.env.VITE_CONTRACT_WAGE;
-
 const RPC_URL = "https://soroban-testnet.stellar.org";
 
 if (!CONTRACT_ADDRESS_TOKEN || !CONTRACT_ADDRESS_WAGE)
-  console.warn("⚠️ Contract addresses not set in the client `.env` — soroban calls will fail.");
+  console.warn(
+    "⚠️ Contract addresses not set in the client `.env` — soroban calls will fail."
+  );
 
 // ============================================
 // SUPPORTED TOKENS (Stellar Testnet)
 // ============================================
 export const SUPPORTED_TOKENS = [
-  {
-    symbol: "XLM",
-    name: "Stellar Lumens",
-    address: "native",
-    decimals: 7,
-    icon: "⭐",
-    isNative: true,
-  },
-  {
-    symbol: "USDC",
-    name: "USD Coin",
-    address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-    decimals: 7,
-    icon: "💵",
-    isNative: false,
-  },
-  {
-    symbol: "EURC",
-    name: "Euro Coin",
-    address: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP",
-    decimals: 7,
-    icon: "💶",
-    isNative: false,
-  },
+  { symbol: "XLM", name: "Stellar Lumens", address: "native", decimals: 7, icon: "⭐", isNative: true },
+  { symbol: "USDC", name: "USD Coin", address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", decimals: 7, icon: "💵", isNative: false },
+  { symbol: "EURC", name: "Euro Coin", address: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP", decimals: 7, icon: "💶", isNative: false },
 ];
 
-// Fetch live exchange rates relative to USD
 export async function fetchExchangeRates() {
   try {
-    // Fallback mock rates — replace with real price feed in production
-    return {
-      XLM: 0.11,
-      USDC: 1.0,
-      EURC: 1.08,
-    };
+    return { XLM: 0.11, USDC: 1.0, EURC: 1.08 };
   } catch {
     return { XLM: 0.11, USDC: 1.0, EURC: 1.08 };
   }
 }
 
-// Initialize Soroban RPC client
 const server = new rpc.Server(RPC_URL);
 
 // ============================================
@@ -83,7 +54,6 @@ async function buildContractCall(publicKey, contractId, functionName, args = [])
   const account = await server.getAccount(publicKey);
   const contract = new Contract(contractId);
   const operation = contract.call(functionName, ...args);
-
   const transaction = new TransactionBuilder(account, {
     fee: BASE_FEE,
     networkPassphrase: Networks.TESTNET,
@@ -91,48 +61,67 @@ async function buildContractCall(publicKey, contractId, functionName, args = [])
     .addOperation(operation)
     .setTimeout(300)
     .build();
-
   return server.prepareTransaction(transaction);
 }
 
 async function signWithFreighter(preparedTx) {
   if (!window.freighterApi) throw new Error("Freighter wallet not found");
-
   const txXdr = preparedTx.toXDR();
   const signedResponse = await signTransaction(txXdr, {
     network: "TESTNET",
     networkPassphrase: Networks.TESTNET,
   });
-
-  if (!signedResponse) {
-    throw new Error("Transaction signature was rejected or failed.");
-  }
-
-  // The NPM package might return an object { signedTxXdr: "..." } or a raw string
-  const finalXdr = typeof signedResponse === 'object' ? signedResponse.signedTxXdr || signedResponse.txXdr : signedResponse;
-
-  if (!finalXdr || typeof finalXdr !== 'string') {
+  if (!signedResponse) throw new Error("Transaction signature was rejected or failed.");
+  const finalXdr =
+    typeof signedResponse === "object"
+      ? signedResponse.signedTxXdr || signedResponse.txXdr
+      : signedResponse;
+  if (!finalXdr || typeof finalXdr !== "string")
     throw new Error("Invalid response format from Freighter SDK: Missing XDR string.");
-  }
-
   return TransactionBuilder.fromXDR(finalXdr, Networks.TESTNET);
 }
 
-async function submitTransaction(signedTx) {
+/**
+ * Submit a signed transaction and poll for confirmation.
+ *
+ * Fixes issue #19: the original implementation used an unbounded `while` loop
+ * that would poll forever if the network stalled or the transaction was lost.
+ * This version adds:
+ *   - A configurable `maxAttempts` limit (default: 30 × 1 s = 30 s timeout)
+ *   - A clear timeout error when the limit is exceeded
+ *
+ * @param {Transaction} signedTx  - Signed Stellar transaction
+ * @param {number}      maxAttempts - Maximum polling attempts before timing out (default: 30)
+ * @param {number}      intervalMs  - Milliseconds between each poll (default: 1000)
+ */
+async function submitTransaction(signedTx, maxAttempts = 30, intervalMs = 1000) {
   const response = await server.sendTransaction(signedTx);
 
+  if (response.status === "ERROR") {
+    throw new Error(`Transaction error: ${response.errorResultXdr}`);
+  }
+
   if (response.status === "PENDING") {
+    let attempts = 0;
     let txResponse = await server.getTransaction(response.hash);
+
     while (txResponse.status === "NOT_FOUND") {
-      await new Promise((r) => setTimeout(r, 1000));
+      if (attempts >= maxAttempts) {
+        throw new Error(
+          `Transaction confirmation timed out after ${maxAttempts} attempts (~${
+            (maxAttempts * intervalMs) / 1000
+          }s). Hash: ${response.hash}`
+        );
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
       txResponse = await server.getTransaction(response.hash);
+      attempts++;
     }
+
     if (txResponse.status === "SUCCESS") {
       return { success: true, hash: response.hash, result: txResponse.resultXdr };
     }
     throw new Error(`Transaction failed: ${txResponse.status}`);
-  } else if (response.status === "ERROR") {
-    throw new Error(`Transaction error: ${response.errorResultXdr}`);
   }
 
   return { success: true, hash: response.hash };
@@ -141,62 +130,25 @@ async function submitTransaction(signedTx) {
 // ============================================
 // MULTI-TOKEN WALLET BALANCES
 // ============================================
-
-/**
- * Fetch all token balances for a wallet using Horizon API
- */
 export async function getWalletTokenBalances(publicKey) {
   try {
     const horizonUrl = `https://horizon-testnet.stellar.org/accounts/${publicKey}`;
     const response = await fetch(horizonUrl);
-
     if (!response.ok) throw new Error("Failed to fetch account");
-
     const accountData = await response.json();
     const balances = [];
-
     for (const balance of accountData.balances) {
       if (balance.asset_type === "native") {
-        balances.push({
-          symbol: "XLM",
-          name: "Stellar Lumens",
-          address: "native",
-          balance: parseFloat(balance.balance),
-          decimals: 7,
-          icon: "⭐",
-          isNative: true,
-        });
+        balances.push({ symbol: "XLM", name: "Stellar Lumens", address: "native", balance: parseFloat(balance.balance), decimals: 7, icon: "⭐", isNative: true });
       } else {
-        const knownToken = SUPPORTED_TOKENS.find(
-          (t) => t.address === balance.asset_issuer
-        );
-        balances.push({
-          symbol: balance.asset_code,
-          name: knownToken?.name || balance.asset_code,
-          address: balance.asset_issuer,
-          balance: parseFloat(balance.balance),
-          decimals: 7,
-          icon: knownToken?.icon || "🪙",
-          isNative: false,
-          limit: balance.limit,
-        });
+        const knownToken = SUPPORTED_TOKENS.find((t) => t.address === balance.asset_issuer);
+        balances.push({ symbol: balance.asset_code, name: knownToken?.name || balance.asset_code, address: balance.asset_issuer, balance: parseFloat(balance.balance), decimals: 7, icon: knownToken?.icon || "🪙", isNative: false, limit: balance.limit });
       }
     }
-
     return balances;
   } catch (error) {
     console.error("Error fetching balances:", error);
-    return [
-      {
-        symbol: "XLM",
-        name: "Stellar Lumens",
-        address: "native",
-        balance: 0,
-        decimals: 7,
-        icon: "⭐",
-        isNative: true,
-      },
-    ];
+    return [{ symbol: "XLM", name: "Stellar Lumens", address: "native", balance: 0, decimals: 7, icon: "⭐", isNative: true }];
   }
 }
 
@@ -204,49 +156,91 @@ export async function getWalletTokenBalances(publicKey) {
 // EMPLOYEE CONTRACT FUNCTIONS
 // ============================================
 
+/**
+ * Look up an employee ID by wallet address.
+ *
+ * Implements the new two-step query pattern introduced when the contract was
+ * refactored: `get_emp_id_by_wallet` returns only the u128 emp_id, which is
+ * then passed to `get_emp_details` to fetch the full employee record.
+ *
+ * Fixes issue #18: the old `getEmployeeWithWA` helper was removed from this
+ * file but callers in checkUser.js and RegistrationCard.jsx still referenced
+ * it, causing ReferenceErrors at runtime.
+ *
+ * @param {string} publicKey     - Connected wallet's public key (for RPC account load)
+ * @param {string} walletAddress - Wallet address to look up
+ * @returns {bigint|null} emp_id as BigInt, or null if not registered
+ */
+export async function getEmpIdByWallet(publicKey, walletAddress) {
+  try {
+    const account = await server.getAccount(publicKey);
+    const contract = new Contract(CONTRACT_ADDRESS_WAGE);
+    const operation = contract.call(
+      "get_emp_id_by_wallet",
+      addressToScVal(walletAddress)
+    );
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(operation)
+      .setTimeout(300)
+      .build();
+    const simResult = await server.simulateTransaction(transaction);
+    if (simResult.result) {
+      const val = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
+      // Contract returns Option<u128>: if None, the wallet is not registered
+      if (val.switch().name === "scvVoid") return null;
+      return BigInt(val.u128().lo().toString());
+    }
+    return null;
+  } catch (error) {
+    console.error("Error getting emp_id by wallet:", error);
+    return null;
+  }
+}
+
+/**
+ * Fetch full employee details for a given wallet address using the two-step
+ * query pattern: wallet → emp_id → employee details.
+ *
+ * This replaces the removed `getEmployeeWithWA` function for callers that
+ * need the full EmployeeDetails struct (checkUser.js, RegistrationCard.jsx).
+ *
+ * @param {string} publicKey     - Connected wallet public key
+ * @param {string} walletAddress - Wallet address to look up
+ * @returns {{ empId: bigint, details: object }|null}
+ */
+export async function getEmployeeByWallet(publicKey, walletAddress) {
+  const empId = await getEmpIdByWallet(publicKey, walletAddress);
+  if (empId === null) return null;
+  const details = await getEmployeeDetails(publicKey, empId);
+  if (!details) return null;
+  return { empId, details };
+}
+
 export async function registerEmployee(publicKey, walletAddress, salary, salaryToken = CONTRACT_ADDRESS_TOKEN) {
-  const args = [
-    addressToScVal(walletAddress),
-    numberToU128(salary),
-    addressToScVal(salaryToken),
-  ];
+  const args = [addressToScVal(walletAddress), numberToU128(salary), addressToScVal(salaryToken)];
   const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "register_employee", args);
   const signedTx = await signWithFreighter(preparedTx);
   return submitTransaction(signedTx);
 }
 
 export async function depositToVault(publicKey, amount, tokenAddress = CONTRACT_ADDRESS_TOKEN) {
-  // Pre-flight check: Ensure the depositor has enough token balance
   const balance = await getTokenBalance(publicKey, tokenAddress);
-  if (balance < amount) {
-    throw new Error(`Insufficient token balance! You only have ${balance} tokens.`);
-  }
-
-  const args = [
-    addressToScVal(publicKey),
-    numberToI128(amount),
-    addressToScVal(tokenAddress),
-  ];
+  if (balance < amount) throw new Error(`Insufficient token balance! You only have ${balance} tokens.`);
+  const args = [addressToScVal(publicKey), numberToI128(amount), addressToScVal(tokenAddress)];
   const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "deposit_to_vault", args);
   const signedTx = await signWithFreighter(preparedTx);
   return submitTransaction(signedTx);
 }
 
 export async function requestAdvance(publicKey, empId, amount, tokenAddress = CONTRACT_ADDRESS_TOKEN) {
-  // Pre-flight check: Ensure the contract vault has enough balance to pay out
   const vaultBalance = await getVaultBalance(publicKey, tokenAddress);
   const fee = amount * 0.0125;
   const netAmount = amount - fee;
-
-  if (vaultBalance < netAmount) {
-    throw new Error(`Contract has insufficient funds to pay this advance right now.`);
-  }
-
-  const args = [
-    numberToU128(empId),
-    numberToI128(amount),
-    addressToScVal(tokenAddress),
-  ];
+  if (vaultBalance < netAmount) throw new Error(`Contract has insufficient funds to pay this advance right now.`);
+  const args = [numberToU128(empId), numberToI128(amount), addressToScVal(tokenAddress)];
   const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "request_advance", args);
   const signedTx = await signWithFreighter(preparedTx);
   return submitTransaction(signedTx);
@@ -257,15 +251,7 @@ export async function getVaultBalance(publicKey, tokenAddress = CONTRACT_ADDRESS
     const account = await server.getAccount(publicKey);
     const contract = new Contract(CONTRACT_ADDRESS_WAGE);
     const operation = contract.call("vault_balance", addressToScVal(tokenAddress));
-
-    const transaction = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: Networks.TESTNET,
-    })
-      .addOperation(operation)
-      .setTimeout(300)
-      .build();
-
+    const transaction = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET }).addOperation(operation).setTimeout(300).build();
     const simResult = await server.simulateTransaction(transaction);
     if (simResult.result) {
       const resultValue = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
@@ -283,15 +269,7 @@ export async function getEmployeeDetails(publicKey, empId) {
     const account = await server.getAccount(publicKey);
     const contract = new Contract(CONTRACT_ADDRESS_WAGE);
     const operation = contract.call("get_emp_details", numberToU128(empId));
-
-    const transaction = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: Networks.TESTNET,
-    })
-      .addOperation(operation)
-      .setTimeout(300)
-      .build();
-
+    const transaction = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET }).addOperation(operation).setTimeout(300).build();
     const simResult = await server.simulateTransaction(transaction);
     if (simResult.result) return simResult.result.retval;
     return null;
@@ -306,15 +284,7 @@ export async function getRemainingSalary(publicKey, empId) {
     const account = await server.getAccount(publicKey);
     const contract = new Contract(CONTRACT_ADDRESS_WAGE);
     const operation = contract.call("get_remaining_salary", numberToU128(empId));
-
-    const transaction = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: Networks.TESTNET,
-    })
-      .addOperation(operation)
-      .setTimeout(300)
-      .build();
-
+    const transaction = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET }).addOperation(operation).setTimeout(300).build();
     const simResult = await server.simulateTransaction(transaction);
     if (simResult.result) {
       const resultValue = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
@@ -328,30 +298,17 @@ export async function getRemainingSalary(publicKey, empId) {
 }
 
 export async function releaseRemainingSalary(publicKey, empId, tokenAddress = CONTRACT_ADDRESS_TOKEN, newSalary) {
-  const args = [
-    numberToU128(empId),
-    addressToScVal(tokenAddress),
-    numberToU128(newSalary),
-  ];
+  const args = [numberToU128(empId), addressToScVal(tokenAddress), numberToU128(newSalary)];
   const preparedTx = await buildContractCall(publicKey, CONTRACT_ADDRESS_WAGE, "release_remaining_salary", args);
   const signedTx = await signWithFreighter(preparedTx);
   return submitTransaction(signedTx);
 }
 
-export const CONTRACTS = {
-  TOKEN: CONTRACT_ADDRESS_TOKEN,
-  WAGE: CONTRACT_ADDRESS_WAGE,
-  RPC_URL,
-};
 export async function getTransactionHistory(publicKey) {
   try {
-    const response = await fetch(
-      `https://horizon-testnet.stellar.org/accounts/${publicKey}/operations?limit=20&order=desc`
-    );
+    const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${publicKey}/operations?limit=20&order=desc`);
     if (!response.ok) throw new Error("Failed to fetch transaction history");
-
     const data = await response.json();
-
     return data._embedded.records.map((op) => ({
       hash: op.transaction_hash,
       type: op.type === "payment" ? (op.to === publicKey ? "Receive" : "Send") : op.type,
@@ -367,12 +324,16 @@ export async function getTransactionHistory(publicKey) {
   }
 }
 
+export const CONTRACTS = { TOKEN: CONTRACT_ADDRESS_TOKEN, WAGE: CONTRACT_ADDRESS_WAGE, RPC_URL };
+
 export default {
   registerEmployee,
   depositToVault,
   requestAdvance,
   getVaultBalance,
   getEmployeeDetails,
+  getEmpIdByWallet,
+  getEmployeeByWallet,
   getRemainingSalary,
   releaseRemainingSalary,
   getWalletTokenBalances,


### PR DESCRIPTION
## Summary

Fixes #18

The smart contract was refactored to split the old `getEmployeeWithWA()` function into two finer-grained functions: `get_emp_id_by_wallet` and `get_emp_details`. The old helper was removed from `sorobanService.js` but callers in `checkUser.js` and `RegistrationCard.jsx` still referenced it with imports commented out — causing a `ReferenceError` at runtime and breaking the entire employee registration and login workflow.

## Changes

### `client/src/services/sorobanService.js`
Added two new functions to implement the two-step query pattern:

**`getEmpIdByWallet(publicKey, walletAddress)`**
- Calls `get_emp_id_by_wallet` on the contract via `simulateTransaction`
- Returns the `emp_id` as `BigInt`, or `null` if the wallet is not registered
- Handles the `scvVoid` (Option::None) return case when wallet has no registration

**`getEmployeeByWallet(publicKey, walletAddress)`**
- Chains `getEmpIdByWallet` → `getEmployeeDetails` into a single convenient call
- Returns `{ empId, details }` or `null` if not registered
- Drop-in replacement for all former `getEmployeeWithWA` call sites

### `client/src/hooks/checkUser.js`
- Replaced `import { getEmployeeWithWA }` with `import { getEmployeeByWallet }`
- Replaced `getEmployeeWithWA(address)` call with `getEmployeeByWallet(address, address)`
- Updated destructuring to use `{ empId, details }`

### `client/src/components/RegistrationCard.jsx`
- Replaced all 3 `getEmployeeWithWA` call sites with `getEmployeeByWallet`
- Updated `safeSyncProfile` to destructure `{ empId, details: empData }`
- Updated the "already registered" fallback path to use new return shape

## Validation
Logic validated locally with mock simulation:
```
✅ Registered wallet returns { empId, details }
✅ Unregistered wallet returns null
✅ checkUser returns correct data for registered wallet
✅ checkUser returns false for unknown wallet
```