### PR TITLE
fix: wire get_emp_id_by_wallet + get_emp_details to frontend registra…

### DIFF
--- a/client/src/components/RegistrationCard.jsx
+++ b/client/src/components/RegistrationCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useEmployeeStore } from "../store/empStore";
-import {  registerEmployee } from "../services/sorobanService";//getEmployeeWithWA
+import {  registerEmployee, getEmployeeWithWA } from "../services/sorobanService";
 import { useWalletContext } from "../context/WalletContext";
 import Card from "./Cards";
 import Button from "./Button";

--- a/client/src/hooks/checkUser.js
+++ b/client/src/hooks/checkUser.js
@@ -1,4 +1,4 @@
-import { registerEmployee } from "../services/sorobanService.js"; //getEmployeeWithWA,
+import { registerEmployee, getEmployeeWithWA } from "../services/sorobanService.js";
 import { useCallback } from "react";
 import { useEmployeeStore } from "../store/empStore.js";
 
@@ -20,6 +20,7 @@ export function useCheckUser() {
         try {
             setLoading(true)
             const empData = await getEmployeeWithWA(address);
+            if (!empData) return { isRegistered: false };
             setEmpData({
                 empId: empData.empId,
                 salary: empData.rem_salary / 10000000,

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -301,6 +301,57 @@ export async function getEmployeeDetails(publicKey, empId) {
   }
 }
 
+/**
+ * Look up a full employee record by wallet address.
+ * Chains get_emp_id_by_wallet → get_emp_details.
+ * Returns a plain object { empId, wallet, rem_salary, salary_token }
+ * or null if the wallet is not registered (emp_id === 0).
+ */
+export async function getEmployeeWithWA(walletAddress) {
+  try {
+    const account = await server.getAccount(walletAddress);
+    const contract = new Contract(CONTRACT_ADDRESS_WAGE);
+
+    // Step 1: resolve wallet → emp_id
+    const idTx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(contract.call("get_emp_id_by_wallet", addressToScVal(walletAddress)))
+      .setTimeout(300)
+      .build();
+
+    const idSim = await server.simulateTransaction(idTx);
+    if (!idSim.result) return null;
+
+    const empId = Number(scValToNative(idSim.result.retval));
+    if (empId === 0) return null; // wallet not registered
+
+    // Step 2: resolve emp_id → full details
+    const detailsTx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(contract.call("get_emp_details", numberToU128(empId)))
+      .setTimeout(300)
+      .build();
+
+    const detailsSim = await server.simulateTransaction(detailsTx);
+    if (!detailsSim.result) return null;
+
+    const raw = scValToNative(detailsSim.result.retval);
+    return {
+      empId: Number(raw.emp_id),
+      wallet: raw.wallet,
+      rem_salary: Number(raw.rem_salary),
+      salary_token: raw.salary_token,
+    };
+  } catch (error) {
+    console.error("Error in getEmployeeWithWA:", error);
+    return null;
+  }
+}
+
 export async function getRemainingSalary(publicKey, empId) {
   try {
     const account = await server.getAccount(publicKey);
@@ -373,6 +424,7 @@ export default {
   requestAdvance,
   getVaultBalance,
   getEmployeeDetails,
+  getEmployeeWithWA,
   getRemainingSalary,
   releaseRemainingSalary,
   getWalletTokenBalances,


### PR DESCRIPTION
…tion flow

## Problem

After the contract refactor, getEmployeeWithWA() was removed from sorobanService.js but its call sites in 
checkUser.js (L22) and RegistrationCard.jsx (L59, L80) were left with the imports commented out instead of 
replaced. This caused a ReferenceError at runtime, breaking the entire registration flow.

## Changes

sorobanService.js
- Added getEmployeeWithWA(walletAddress) that chains the two new contract functions:
  1. get_emp_id_by_wallet(wallet) → resolves wallet to emp_id (returns null if emp_id === 0, i.e. unregistered)
  2. get_emp_details(emp_id) → fetches full EmployeeDetails struct
- Added to default export

checkUser.js
- Restored getEmployeeWithWA import
- Added if (!empData) return { isRegistered: false } null-check — clean path for unregistered wallets, no longer 
relies on error message string matching

RegistrationCard.jsx
- Restored getEmployeeWithWA import

## Closes #18