### PR TITLE
fix: resolve wallet connection redirect and registration flow (#43)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,12 +10,6 @@ function App() {
   const isOnEmployer = location.pathname.startsWith('/employer');
   const targetPath = isOnEmployer ? '/' : '/employer';
   const label = isOnEmployer ? 'Home' : 'Employer Dashboard';
-import TransactionHistory from './components/TransactionHistory';
-import { useWallet } from './hooks/useWallet';
-
-function App() {
-  const [view, setView] = useState('home');
-  const { transactions } = useWallet();
 
   return (
     <WalletProvider>
@@ -48,9 +42,6 @@ function App() {
         <Route path="*" element={<NotFound />} />
       </Routes>
     </WalletProvider>
-      {view === 'employer' ? <EmployerDashboard /> : <HomePage />}
-      <TransactionHistory transactions={transactions} />
-    </>
   );
 }
 

--- a/client/src/components/HomePage.jsx
+++ b/client/src/components/HomePage.jsx
@@ -43,11 +43,10 @@ const HomePage = () => {
   const [notification, setNotification] = useState(null);
   const [showSendModal, setShowSendModal] = useState(false);
   const [showWaitlistModal, setShowWaitlistModal] = useState(false);
-  const [showRegisterModal, setShowRegisterModal] = useState(false); //to check if a user is registered or not 
-
+  const [showRegisterModal, setShowRegisterModal] = useState(false);
+  const [isRegisteredUser, setIsRegisteredUser] = useState(false);
 
   const fetchEmployeeData = useCallback(async () => {
-    // this function uses hooks to check whether a user is registered or not;
     if (!walletAddress) return;
 
     try {
@@ -59,7 +58,7 @@ const HomePage = () => {
         return;
       }
 
-      // If registered, hide the modal forcefully and load scaled salary
+      setIsRegisteredUser(true);
       setShowRegisterModal(false);
 
       const scaledSalary = empData?.rem_salary
@@ -69,6 +68,8 @@ const HomePage = () => {
 
     } catch (error) {
       console.error("Error fetching employee data in HomePage:", error);
+      // Contract unreachable or not configured — show registration choice
+      setShowRegisterModal(true);
     } finally {
       setIsLoading(false);
     }
@@ -472,8 +473,10 @@ const HomePage = () => {
         <RegistrationCard
           onSuccess={() => {
             setShowRegisterModal(false);
-            fetchEmployeeData();
+            setIsRegisteredUser(true);
+            showNotification("Welcome to StellarPay! Your account is ready.");
           }}
+          onSkip={() => setShowRegisterModal(false)}
         />
       )}
 

--- a/client/src/components/RegistrationCard.jsx
+++ b/client/src/components/RegistrationCard.jsx
@@ -1,19 +1,20 @@
 import React, { useState } from "react";
 import { useEmployeeStore } from "../store/empStore";
-import {  registerEmployee } from "../services/sorobanService";//getEmployeeWithWA
+import {  registerEmployee, getEmployeeWithWA } from "../services/sorobanService";
 import { useWalletContext } from "../context/WalletContext";
 import Card from "./Cards";
 import Button from "./Button";
 import InputField from "./InputField";
 
 
-const RegistrationCard = ({ onSuccess }) => {
+const RegistrationCard = ({ onSuccess, onSkip }) => {
     const { walletAddress } = useWalletContext();
     const setEmpData = useEmployeeStore((state) => state.setEmpData);
     const setError = useEmployeeStore((state) => state.setError);
     const isRegistered = useEmployeeStore((state) => state.isRegistered);
     // Remove global loading states that get stuck on app init
     const [isLoading, setIsLoading] = useState(false);
+    const [successMsg, setSuccessMsg] = useState("");
 
     const [form, setForm] = useState({
         salary: "",
@@ -53,26 +54,16 @@ const RegistrationCard = ({ onSuccess }) => {
                 return;
             }
 
-            // Fast & Safe Recursive Strategy: The blockchain takes a few seconds to sync.
-            // We recursively poll the network without blocking the main event thread.
-            const safeSyncProfile = async (attempts = 3) => {
-                const data = await getEmployeeWithWA(walletAddress);
-                if (data) return data; // Success! Sync caught up.
-                if (attempts <= 0) throw new Error("Registration confirmed, but profile failed to sync.");
-                await new Promise(res => setTimeout(res, 2000)); // 2-second safe buffer
-                return safeSyncProfile(attempts - 1);
-            };
-
-            const empData = await safeSyncProfile();
-
+            // Store what we know locally — no need to re-query the contract immediately
             setEmpData({
-                empId: empData?.empId || null,
+                empId: null,
                 salary: Number(form.salary),
                 email: form.email,
                 isRegistered: true,
             });
 
-            onSuccess?.();
+            setSuccessMsg("Registration successful! Redirecting to dashboard...");
+            setTimeout(() => onSuccess?.(), 1500);
         } catch (error) {
             // Check if the Blockchain rejected it because we are ALREADY registered
             if (error.message?.includes("InvalidAction") || error.message?.includes("UnreachableCodeReached")) {
@@ -107,14 +98,25 @@ const RegistrationCard = ({ onSuccess }) => {
             <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 sm:p-6">
                 <Card className="w-full max-w-md mx-auto">
                     {/* Header */}
-                    <div className="flex items-center gap-3 mb-8">
-                        <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center">
-                            <span className="text-lg">✦</span>
+                    <div className="flex items-center justify-between mb-8">
+                        <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center">
+                                <span className="text-lg">✦</span>
+                            </div>
+                            <div>
+                                <h2 className="text-xl font-semibold text-white">Register Account</h2>
+                                <p className="text-gray-500 text-sm">Set up your employee profile</p>
+                            </div>
                         </div>
-                        <div>
-                            <h2 className="text-xl font-semibold text-white">Register Account</h2>
-                            <p className="text-gray-500 text-sm">Set up your employee profile</p>
-                        </div>
+                        {onSkip && (
+                            <button
+                                onClick={onSkip}
+                                className="text-gray-500 hover:text-gray-300 transition-colors text-sm underline"
+                                title="Go to dashboard without registering"
+                            >
+                                Skip →
+                            </button>
+                        )}
                     </div>
 
                     <div className="w-full h-px bg-white/10 mb-8" />
@@ -148,13 +150,27 @@ const RegistrationCard = ({ onSuccess }) => {
                         </div>
 
                         <div className="flex flex-col gap-3 mt-2">
+                            {successMsg && (
+                                <div className="p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 text-sm text-center">
+                                    ✓ {successMsg}
+                                </div>
+                            )}
                             <Button
                                 onClick={handleSubmit}
                                 isLoading={isLoading}
-                                disabled={!form.email || !form.salary}
+                                disabled={!form.email || !form.salary || !!successMsg}
                             >
                                 Register ✦
                             </Button>
+                            {onSkip && (
+                                <button
+                                    type="button"
+                                    onClick={onSkip}
+                                    className="text-gray-500 hover:text-gray-300 transition-colors text-sm text-center py-1"
+                                >
+                                    Already registered? Go to Dashboard →
+                                </button>
+                            )}
                         </div>
                     </div>
                 </Card>

--- a/client/src/hooks/checkUser.js
+++ b/client/src/hooks/checkUser.js
@@ -1,13 +1,10 @@
-import { registerEmployee } from "../services/sorobanService.js"; //getEmployeeWithWA,
+import { getEmployeeWithWA } from "../services/sorobanService.js";
 import { useCallback } from "react";
 import { useEmployeeStore } from "../store/empStore.js";
 
-//creating a custom hook to check if a user
-//is registered or not in a system
+const CONTRACT_WAGE = import.meta.env.VITE_CONTRACT_WAGE;
 
 export function useCheckUser() {
-    //using zustand here 
-    //to manage state
     const setEmpData = useEmployeeStore((state) => state.setEmpData);
     const setError = useEmployeeStore((state) => state.setError);
     const setLoading = useEmployeeStore((state) => state.setLoading);
@@ -17,14 +14,20 @@ export function useCheckUser() {
             return { isRegistered: false };
         }
 
+        // No contract configured — skip check, treat as registered so dashboard loads
+        if (!CONTRACT_WAGE) {
+            console.warn("VITE_CONTRACT_WAGE not set — skipping registration check.");
+            return { isRegistered: true, empData: null };
+        }
+
         try {
-            setLoading(true)
+            setLoading(true);
             const empData = await getEmployeeWithWA(address);
             setEmpData({
                 empId: empData.empId,
                 salary: empData.rem_salary / 10000000,
                 email: empData.email,
-            })
+            });
             return { isRegistered: true, empData };
 
         } catch (error) {
@@ -36,15 +39,16 @@ export function useCheckUser() {
                 error.message?.includes("Wallet not registered");
 
             if (!isNotRegistered) {
-                console.error("checkUser caught an unexpected bug, NOT a simple 'wallet missing' error:", error);
+                console.error("checkUser caught an unexpected error:", error);
+                // Unknown error (network, RPC down, etc.) — don't block the user
+                return { isRegistered: true, empData: null };
             }
 
             return { isRegistered: false };
-        }
-        finally {
+        } finally {
             setLoading(false);
         }
     }, []);
 
-    return { checkUser }
+    return { checkUser };
 }

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -327,6 +327,51 @@ export async function getRemainingSalary(publicKey, empId) {
   }
 }
 
+/**
+ * Look up an employee record by their wallet address via contract simulation.
+ * Returns { empId, rem_salary, email } or throws if not found.
+ */
+export async function getEmployeeWithWA(walletAddress) {
+  try {
+    const account = await server.getAccount(walletAddress);
+    const contract = new Contract(CONTRACT_ADDRESS_WAGE);
+    const operation = contract.call("get_employee_by_wallet", addressToScVal(walletAddress));
+
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(operation)
+      .setTimeout(300)
+      .build();
+
+    const simResult = await server.simulateTransaction(transaction);
+
+    if (!simResult.result) {
+      throw new Error("Wallet not registered");
+    }
+
+    const native = scValToNative(simResult.result.retval);
+
+    // Contract returns a map/struct — normalise field names defensively
+    return {
+      empId: native.emp_id ?? native.empId ?? null,
+      rem_salary: native.rem_salary ?? native.salary ?? 0,
+      email: native.email ?? "",
+    };
+  } catch (error) {
+    // Re-throw with a recognisable message so callers can detect "not registered"
+    if (
+      error.message?.includes("WasmVm") ||
+      error.message?.includes("InvalidAction") ||
+      error.message?.includes("simulation failed")
+    ) {
+      throw new Error("Wallet not registered");
+    }
+    throw error;
+  }
+}
+
 export async function releaseRemainingSalary(publicKey, empId, tokenAddress = CONTRACT_ADDRESS_TOKEN, newSalary) {
   const args = [
     numberToU128(empId),
@@ -369,6 +414,7 @@ export async function getTransactionHistory(publicKey) {
 
 export default {
   registerEmployee,
+  getEmployeeWithWA,
   depositToVault,
   requestAdvance,
   getVaultBalance,


### PR DESCRIPTION
This PR fixes a broken onboarding flow where users were force-redirected to the registration form on every wallet connection with no way to access the dashboard, and where registration submission produced no visible response or redirect.

## Root Causes

- App.jsx had a corrupted merge artifact with two conflicting function App() declarations and import statements inside the function body, causing a Babel parse error and a blank page on load.

- checkUser.js imported registerEmployee but called getEmployeeWithWA which was never imported, causing a ReferenceError on every wallet connection attempt.

- sorobanService.js had no getEmployeeWithWA function exported at all, despite being called in both checkUser.js and RegistrationCard.jsx.

- checkUser caught ALL errors (network, RPC, missing contract) and returned { isRegistered: false }, so with no contract configured or any unexpected failure, users were always shown the registration modal with no escape route.

- RegistrationCard.jsx had getEmployeeWithWA commented out of its import and after a successful registerEmployee call, it attempted to poll the contract via safeSyncProfile which would fail immediately (same missing function), swallowing the success and never calling onSuccess.

- HomePage passed no onSkip prop to RegistrationCard, so users had no way to dismiss the modal and access the dashboard.

## Changes

### client/src/App.jsx
- Removed the corrupted duplicate function body and stray imports that were nested inside the first App() declaration, restoring a valid single-component module.

### client/src/services/sorobanService.js
- Added getEmployeeWithWA(walletAddress) which simulates a contract call to get_employee_by_wallet, normalises the returned struct fields, and throws a recognisable 'Wallet not registered' error for callers to detect unregistered wallets. Added to default export.

### client/src/hooks/checkUser.js
- Fixed import to include getEmployeeWithWA.
- Added a CONTRACT_WAGE guard: if the env var is not set, skip the contract check entirely and return { isRegistered: true } so the dashboard loads without blocki  function), swallowing the success and never calling onSuccess.

- Home a
- HomePan { isRegistered: true } instead of silently forcing th  way to dismis  modal, preventing users from being permanently locked out.

### client/src/components/RegistrationCard.jsx

### cliemport to include getEmploy  wereWA.
- Removed the safeSyncProfile polling block after registration. On a confirmed success response from registerEmployee, employee data is stored directly from form state (no second contract call needed).
- Added successMsg state: shows a green confirmation banner before redirecting, giving users visible feedback that registration worked.
- Added onSkip prop support with a Skip button in the header and an 'Already registered? Go to Dashboard' link at the bottom of the form.

### client/src/components/HomePage.jsx
- Added isRegisteredUser state to track post-registration status locally without re-querying the contract.
- onSuccess callback now sets isRegisteredUser and shows a welcome notification instead of calling fetchEmployeeData again (which would re-trigger the contract check and potentially loop back to the modal).
- onSkip prop passed to RegistrationCard so users can always dismiss the modal and access the dashboard.
- fetchEmployeeData catches unexpected errors and shows the registration modal rather than silently failing.

## Behaviour After Fix

- Wallet connects → contract check runs → if registered, dashboard loads directly → if not registered, modal appears with Skip and Go to Dashboard options so users are never trapped.
- Registration submits → success banner shown → dashboard loads after 1.5s with no second contract round-trip.
- No contract env vars configured → check is skipped, dashboard loads, contract features degrade gracefully with console warnings.

## ScreenRecord


https://github.com/user-attachments/assets/8b5d7a8c-dfd7-47ac-9772-05f89f17dfb0



Closes #43