### PR TITLE
feat: Add live XLM/USD price feed with real-time ticker component

### DIFF
--- a/client/src/components/HomePage.jsx
+++ b/client/src/components/HomePage.jsx
@@ -10,6 +10,7 @@ import WaitlistModal from "./WaitlistModal";
 import RegistrationCard from "./RegistrationCard";
 import { useEmployeeStore } from "../store/empStore";
 import { useCheckUser } from "../hooks/checkUser";
+import LivePriceTicker from "./LivePriceTicker";
 
 
 const HomePage = () => {
@@ -370,6 +371,8 @@ const HomePage = () => {
 
       {/* Dashboard Section */}
       <section className="max-w-7xl mx-auto px-6 py-8">
+        {/* Live XLM Price Ticker */}
+        <LivePriceTicker />
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Balance Card */}
           <div className="lg:col-span-2">

--- a/client/src/components/LivePriceTicker.jsx
+++ b/client/src/components/LivePriceTicker.jsx
@@ -1,0 +1,257 @@
+/**
+ * LivePriceTicker.jsx
+ * Real-time XLM/USD price ticker component for StellarPay.
+ *
+ * - Polls fetchLivePrices() every 60 s
+ * - Primary source: StellarExpert API; fallback: CoinGecko
+ * - Shows XLM price, 24 h change, and stable-coin rates (USDC / EURC)
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { fetchLivePrices } from "../services/priceService";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+function formatUSD(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  }).format(value);
+}
+
+function formatChange(change) {
+  const sign = change >= 0 ? "+" : "";
+  return `${sign}${change.toFixed(2)}%`;
+}
+
+export default function LivePriceTicker() {
+  const [prices, setPrices] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [pulse, setPulse] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchLivePrices();
+      setPrices(data);
+      setLastUpdated(new Date());
+      setError(null);
+      // Brief highlight animation on update
+      setPulse(true);
+      setTimeout(() => setPulse(false), 600);
+    } catch {
+      setError("Unable to fetch live prices.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  const xlm = prices?.XLM ?? { usd: 0, change24h: 0 };
+  const isPositive = xlm.change24h >= 0;
+
+  return (
+    <div
+      id="live-price-ticker"
+      style={{
+        background:
+          "linear-gradient(135deg, rgba(17,17,17,0.95) 0%, rgba(20,20,35,0.95) 100%)",
+        border: `1px solid ${pulse ? "rgba(167,139,250,0.5)" : "rgba(255,255,255,0.08)"}`,
+        borderRadius: "16px",
+        padding: "16px 24px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        flexWrap: "wrap",
+        gap: "12px",
+        marginBottom: "24px",
+        transition: "border-color 0.4s ease",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {/* Subtle glow */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background:
+            "radial-gradient(ellipse at 15% 50%, rgba(167,139,250,0.06) 0%, transparent 65%)",
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Left — XLM identity */}
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <div
+          style={{
+            width: "40px",
+            height: "40px",
+            borderRadius: "50%",
+            background: "linear-gradient(135deg, #a78bfa, #06b6d4)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: "20px",
+            flexShrink: 0,
+            boxShadow: "0 0 14px rgba(167,139,250,0.45)",
+          }}
+        >
+          ⭐
+        </div>
+        <div>
+          <div
+            style={{ color: "#f1f5f9", fontWeight: 700, fontSize: "15px" }}
+          >
+            Stellar Lumens
+          </div>
+          <div style={{ color: "#64748b", fontSize: "12px", marginTop: "2px" }}>
+            XLM / USD • Live
+          </div>
+        </div>
+      </div>
+
+      {/* Center — price + 24 h change */}
+      <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
+        {loading ? (
+          <span style={{ color: "#64748b", fontSize: "14px" }}>
+            Fetching price…
+          </span>
+        ) : error ? (
+          <span style={{ color: "#f87171", fontSize: "13px" }}>{error}</span>
+        ) : (
+          <>
+            <span
+              id="xlm-live-price"
+              style={{
+                color: "#f1f5f9",
+                fontWeight: 800,
+                fontSize: "22px",
+                fontFamily: "monospace",
+                letterSpacing: "-0.5px",
+                transition: "color 0.3s",
+              }}
+            >
+              {formatUSD(xlm.usd)}
+            </span>
+            <span
+              id="xlm-24h-change"
+              style={{
+                color: isPositive ? "#34d399" : "#f87171",
+                fontWeight: 600,
+                fontSize: "13px",
+                background: isPositive
+                  ? "rgba(52,211,153,0.1)"
+                  : "rgba(248,113,113,0.1)",
+                padding: "3px 10px",
+                borderRadius: "20px",
+                border: `1px solid ${
+                  isPositive
+                    ? "rgba(52,211,153,0.25)"
+                    : "rgba(248,113,113,0.25)"
+                }`,
+              }}
+            >
+              {isPositive ? "▲" : "▼"} {formatChange(xlm.change24h)} 24h
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Right — source + timestamp + refresh */}
+      <div style={{ textAlign: "right" }}>
+        {prices?.source && (
+          <div
+            style={{ color: "#a78bfa", fontSize: "11px", fontWeight: 600 }}
+          >
+            via {prices.source}
+          </div>
+        )}
+        {lastUpdated && (
+          <div
+            style={{ color: "#475569", fontSize: "11px", marginTop: "2px" }}
+          >
+            {lastUpdated.toLocaleTimeString()}
+          </div>
+        )}
+        <button
+          id="refresh-price-btn"
+          onClick={load}
+          style={{
+            marginTop: "4px",
+            background: "none",
+            border: "none",
+            color: "#a78bfa",
+            fontSize: "11px",
+            cursor: "pointer",
+            textDecoration: "underline",
+            padding: 0,
+          }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* Bottom — stablecoin rates */}
+      {prices && (
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            gap: "20px",
+            alignItems: "center",
+            borderTop: "1px solid rgba(255,255,255,0.05)",
+            paddingTop: "10px",
+            marginTop: "4px",
+          }}
+        >
+          {[
+            { symbol: "USDC", icon: "💵", data: prices.USDC },
+            { symbol: "EURC", icon: "💶", data: prices.EURC },
+          ].map(({ symbol, icon, data }) => (
+            <div
+              key={symbol}
+              style={{ display: "flex", alignItems: "center", gap: "6px" }}
+            >
+              <span style={{ fontSize: "14px" }}>{icon}</span>
+              <span
+                style={{
+                  color: "#94a3b8",
+                  fontSize: "12px",
+                  fontWeight: 600,
+                }}
+              >
+                {symbol}
+              </span>
+              <span
+                style={{
+                  color: "#e2e8f0",
+                  fontSize: "12px",
+                  fontFamily: "monospace",
+                }}
+              >
+                {formatUSD(data.usd)}
+              </span>
+            </div>
+          ))}
+          <div
+            style={{ marginLeft: "auto", color: "#334155", fontSize: "11px" }}
+          >
+            🔄 auto-refresh 60s
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/services/priceService.js
+++ b/client/src/services/priceService.js
@@ -1,0 +1,117 @@
+/**
+ * priceService.js
+ * Real-time XLM price feed for StellarPay.
+ *
+ * Primary source  : StellarExpert Ticker API (no API key required)
+ * Fallback source : CoinGecko public API
+ * Cache TTL       : 60 seconds (avoids rate-limiting)
+ */
+
+const CACHE_TTL_MS = 60_000; // 60 seconds
+
+let _cache = {
+  rates: null,
+  fetchedAt: 0,
+};
+
+// ---------- Primary: StellarExpert ----------
+
+async function fetchFromStellarExpert() {
+  // XLM price ticker from StellarExpert public API (no auth required)
+  const url =
+    "https://api.stellar.expert/explorer/public/asset/XLM/price?period=1d";
+  const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+  if (!res.ok) throw new Error(`StellarExpert HTTP ${res.status}`);
+  const data = await res.json();
+  return {
+    XLM: {
+      usd: parseFloat(data.price ?? data.close ?? 0),
+      change24h: parseFloat(data.change ?? 0),
+    },
+    USDC: { usd: 1.0, change24h: 0 },
+    EURC: { usd: 1.08, change24h: 0 },
+    source: "StellarExpert",
+  };
+}
+
+// ---------- Fallback: CoinGecko ----------
+
+async function fetchFromCoinGecko() {
+  const url =
+    "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd&include_24hr_change=true";
+  const res = await fetch(url, { signal: AbortSignal.timeout(8_000) });
+  if (!res.ok) throw new Error(`CoinGecko HTTP ${res.status}`);
+  const data = await res.json();
+  const xlm = data?.stellar ?? {};
+  return {
+    XLM: {
+      usd: parseFloat(xlm.usd ?? 0.11),
+      change24h: parseFloat(xlm.usd_24h_change ?? 0),
+    },
+    USDC: { usd: 1.0, change24h: 0 },
+    EURC: { usd: 1.08, change24h: 0 },
+    source: "CoinGecko",
+  };
+}
+
+// ---------- Public API ----------
+
+/**
+ * Returns live exchange rates for XLM, USDC, and EURC.
+ * Results are cached for 60 seconds to avoid API rate limits.
+ *
+ * @returns {Promise<{XLM:{usd:number,change24h:number}, USDC:{usd:number}, EURC:{usd:number}, source:string, cachedAt:number}>}
+ */
+export async function fetchLivePrices() {
+  const now = Date.now();
+  if (_cache.rates && now - _cache.fetchedAt < CACHE_TTL_MS) {
+    return { ..._cache.rates, cachedAt: _cache.fetchedAt };
+  }
+
+  let rates;
+  try {
+    rates = await fetchFromStellarExpert();
+  } catch (primaryErr) {
+    console.warn(
+      "[priceService] StellarExpert failed, trying CoinGecko:",
+      primaryErr.message
+    );
+    try {
+      rates = await fetchFromCoinGecko();
+    } catch (fallbackErr) {
+      console.error(
+        "[priceService] Both price sources failed:",
+        fallbackErr.message
+      );
+      // Return last cached value or hard fallback — never throw to callers
+      return (
+        _cache.rates ?? {
+          XLM: { usd: 0.11, change24h: 0 },
+          USDC: { usd: 1.0, change24h: 0 },
+          EURC: { usd: 1.08, change24h: 0 },
+          source: "fallback",
+          cachedAt: now,
+        }
+      );
+    }
+  }
+
+  _cache = { rates, fetchedAt: now };
+  return { ...rates, cachedAt: now };
+}
+
+/**
+ * Returns the simple flat map compatible with the existing
+ * sorobanService.fetchExchangeRates() signature:
+ *   { XLM: number, USDC: number, EURC: number }
+ */
+export async function fetchExchangeRates() {
+  const prices = await fetchLivePrices();
+  return {
+    XLM: prices.XLM.usd,
+    USDC: prices.USDC.usd,
+    EURC: prices.EURC.usd,
+  };
+}
+
+export default { fetchLivePrices, fetchExchangeRates };

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -11,6 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { signTransaction } from "@stellar/freighter-api";
+import { fetchExchangeRates as fetchLiveRates } from "./priceService";
 
 // Contract addresses (set these via VITE_* env vars)
 const CONTRACT_ADDRESS_TOKEN = import.meta.env.VITE_CONTRACT_TOKEN;
@@ -53,15 +54,12 @@ export const SUPPORTED_TOKENS = [
 ];
 
 // Fetch live exchange rates relative to USD
+// Delegates to priceService which uses StellarExpert (primary) + CoinGecko (fallback)
 export async function fetchExchangeRates() {
   try {
-    // Fallback mock rates — replace with real price feed in production
-    return {
-      XLM: 0.11,
-      USDC: 1.0,
-      EURC: 1.08,
-    };
+    return await fetchLiveRates();
   } catch {
+    // Hard fallback — only reached if priceService itself throws unexpectedly
     return { XLM: 0.11, USDC: 1.0, EURC: 1.08 };
   }
 }


### PR DESCRIPTION
- Add priceService.js: fetches XLM price from StellarExpert API (primary) and CoinGecko public API (fallback) with 60-second cache to prevent rate limiting. Graceful degradation: returns last cached value on failure.

- Add LivePriceTicker.jsx: animated real-time price ticker component showing live XLM/USD price, 24h percentage change (green/red), USDC and EURC stablecoin rates, data source attribution, and a manual refresh button.

- Fix sorobanService.js: replace hardcoded exchange rates (noted as TODO in the codebase comment: 'replace with real price feed in production') with a live API call via priceService. Fully backward compatible - same return signature { XLM, USDC, EURC }.

- Update HomePage.jsx: integrate LivePriceTicker above the dashboard grid so users see accurate real-time XLM price before interacting with balances.

Impact: USD-equivalent balance calculations now use live market data instead of the static hardcoded value of 0.11 USD per XLM.