### PR TITLE
Fix/wire contract query functions to registration

### DIFF
--- a/client/src/components/RegistrationCard.jsx
+++ b/client/src/components/RegistrationCard.jsx
@@ -26,7 +26,7 @@ const RegistrationCard = ({ onSuccess }) => {
     });
 
     const dataValidate = () => {
-        const newErrors = { general: "" }; // Clear general error on validation
+        const newErrors = { general: "" };
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
         if (!form.email || !emailRegex.test(form.email)) {
@@ -36,7 +36,8 @@ const RegistrationCard = ({ onSuccess }) => {
             newErrors.salary = "Please enter a valid salary";
         }
         setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
+        // Only email and salary fields count as validation failures
+        return !newErrors.email && !newErrors.salary;
     }
 
     const handleSubmit = async (e) => {
@@ -87,26 +88,26 @@ const RegistrationCard = ({ onSuccess }) => {
             });
 
             onSuccess?.();
-        } catch (error) {
+        } catch (err) {
             // Check if the Blockchain rejected it because we are ALREADY registered
-            if (error.message?.includes("InvalidAction") || error.message?.includes("UnreachableCodeReached")) {
+            if (err.message?.includes("InvalidAction") || err.message?.includes("UnreachableCodeReached")) {
                 try {
                     const existingData = await getEmployeeWithWA(walletAddress);
                     setEmpData({
                         empId: existingData?.empId || null,
                         salary: existingData.rem_salary / 10000000,
-                        email: existingData.email,
-                        isRegistered: true, // Force Zustand to see us!
+                        email: form.email,
+                        isRegistered: true,
                     });
-                    if (onSuccess) onSuccess(); // Notify HomePage
-                    return; // Crucial early exit
+                    if (onSuccess) onSuccess();
+                    return;
                 } catch (readErr) {
                     console.error("Failed to fetch existing profile:", readErr);
                 }
             }
 
-            console.error("CRITICAL REGISTRATION ERROR CAUGHT IN UI:", error);
-            setErrors({ ...error, general: error.message || "An error occurred during registration. Please try again." });
+            console.error("CRITICAL REGISTRATION ERROR CAUGHT IN UI:", err);
+            setErrors((prev) => ({ ...prev, general: err.message || "An error occurred during registration. Please try again." }));
         }
         finally {
             setIsLoading(false);

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -11,7 +11,6 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { signTransaction } from "@stellar/freighter-api";
-import { fetchExchangeRates as fetchLiveRates } from "./priceService";
 
 // Contract addresses (set these via VITE_* env vars)
 const CONTRACT_ADDRESS_TOKEN = import.meta.env.VITE_CONTRACT_TOKEN;

--- a/client/src/services/sorobanService.js
+++ b/client/src/services/sorobanService.js
@@ -395,9 +395,8 @@ export async function getEmployeeIdByWallet(walletAddress) {
 
     const simResult = await server.simulateTransaction(transaction);
     if (simResult.result) {
-      const sc = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
-      const id = Number(sc.u128().lo().toString());
-      return id;
+      const raw = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
+      return Number(scValToNative(raw));
     }
 
     return 0;


### PR DESCRIPTION

## Summary

Closes #18

The registration flow had three distinct bugs that together caused a complete runtime failure. This PR fixes all of them.

---

## Root Cause Analysis

### Bug 1 — Incorrect XDR deserialization in `getEmployeeIdByWallet`

```js
// Before — brittle, breaks on certain SDK versions
const sc = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
const id = Number(sc.u128().lo().toString());

// After — uses the SDK's own converter, handles all u128 encodings correctly
const raw = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
return Number(scValToNative(raw));
```

The manual `.u128().lo()` accessor only reads the low 64 bits and fails when the XDR variant tag does not match exactly. `scValToNative` is the correct, SDK-blessed path for this conversion.

### Bug 2 — `dataValidate()` always returned `false`, blocking every registration attempt

```js
// Before — newErrors always has { general: "" }, so length is never 0
return Object.keys(newErrors).length === 0;

// After — only field-level errors count as failures
return !newErrors.email && !newErrors.salary;
```

This silently prevented the form from ever submitting, even with valid inputs.

### Bug 3 — Shadowed `error` variable corrupted the error state

```js
// Before — catch(error) shadows the state variable; spreading an Error object
// onto setErrors produces { stack: ..., message: ..., general: ... }
} catch (error) {
    setErrors({ ...error, general: error.message || "..." });

// After — renamed to err, uses functional updater to safely merge
} catch (err) {
    setErrors((prev) => ({ ...prev, general: err.message || "..." }));
```

Spreading a native `Error` object into state silently wiped the `email` and `salary` error fields and could cause React to render unexpected values.

---

## Additional Fix

In the already-registered recovery path, `existingData.email` was used — but the contract's `EmployeeDetails` struct has no `email` field. Changed to `form.email` (the value the user just typed), which is the correct source.

---

## Files Changed

| File | Change |
|------|--------|
| `client/src/services/sorobanService.js` | Use `scValToNative` for u128 deserialization in `getEmployeeIdByWallet` |
| `client/src/components/RegistrationCard.jsx` | Fix `dataValidate` return value; fix shadowed `error` variable; fix `email` source in recovery path |

---

## Testing

- [x] Wallet not registered → `checkUser` returns `{ isRegistered: false }`, registration modal shown
- [x] Valid form submission → `dataValidate` returns `true`, registration proceeds
- [x] Successful registration → `safeSyncProfile` polls and syncs Zustand store
- [x] Already-registered wallet → recovery path fetches existing data, sets store, calls `onSuccess`
- [x] Error state → general error message displayed without corrupting field errors

---

## Note on `require_admin`

The contract already has `Self::require_admin(&e)` commented out in `register_employee`, so self-registration works as the issue spec intended. No contract changes are needed.

 - Completed in 1.403s

> Here's the PR description as it appears on GitHub:


## Summary

Closes #18

The registration flow had three distinct bugs that together caused a complete runtime failure. This PR fixes all 
of them.


## Root Cause Analysis

### Bug 1 — Incorrect XDR deserialization in getEmployeeIdByWallet

js
// Before — brittle, breaks on certain SDK versions
const sc = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
const id = Number(sc.u128().lo().toString());

// After — uses the SDK's own converter, handles all u128 encodings correctly
const raw = xdr.ScVal.fromXDR(simResult.result.retval.toXDR());
return Number(scValToNative(raw));


The manual .u128().lo() accessor only reads the low 64 bits and fails when the XDR variant tag does not match 
exactly. scValToNative is the correct, SDK-blessed path for this conversion.

### Bug 2 — dataValidate() always returned false, blocking every registration attempt

js
// Before — newErrors always has { general: "" }, so length is never 0
return Object.keys(newErrors).length === 0;

// After — only field-level errors count as failures
return !newErrors.email && !newErrors.salary;


This silently prevented the form from ever submitting, even with valid inputs.

### Bug 3 — Shadowed error variable corrupted the error state

js
// Before — catch(error) shadows the state variable; spreading an Error object
// onto setErrors produces { stack: ..., message: ..., general: ... }
} catch (error) {
    setErrors({ ...error, general: error.message || "..." });

// After — renamed to err, uses functional updater to safely merge
} catch (err) {
    setErrors((prev) => ({ ...prev, general: err.message || "..." }));


Spreading a native Error object into state silently wiped the email and salary error fields and could cause React 
to render unexpected values.


## Additional Fix

In the already-registered recovery path, existingData.email was used — but the contract's EmployeeDetails struct 
has no email field. Changed to form.email (the value the user just typed), which is the correct source.


## Files Changed

| File | Change |
|------|--------|
| client/src/services/sorobanService.js | Use scValToNative for u128 deserialization in getEmployeeIdByWallet |
| client/src/components/RegistrationCard.jsx | Fix dataValidate return value; fix shadowed error variable; fix 
email source in recovery path |


## Testing

- [x] Wallet not registered → checkUser returns { isRegistered: false }, registration modal shown
- [x] Valid form submission → dataValidate returns true, registration proceeds
- [x] Successful registration → safeSyncProfile polls and syncs Zustand store
- [x] Already-registered wallet → recovery path fetches existing data, sets store, calls onSuccess
- [x] Error state → general error message displayed without corrupting field errors


## Note on require_admin

The contract already has Self::require_admin(&e) commented out in register_employee, so self-registration works as
the issue spec intended. No contract changes are needed.